### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,22 +6,22 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-encoder         KEYWORD1
+encoder	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-getPing         KEYWORD2
-QTI             KEYWORD2
-isRadioOn       KEYWORD2
-getRadioPulse   KEYWORD2
-getRadio        KEYWORD2
-fastDigitalRead KEYWORD2
+getPing	KEYWORD2
+QTI	KEYWORD2
+isRadioOn	KEYWORD2
+getRadioPulse	KEYWORD2
+getRadio	KEYWORD2
+fastDigitalRead	KEYWORD2
 
-begin           KEYWORD2
-getRPM          KEYWORD2
-getRev          KEYWORD2
+begin	KEYWORD2
+getRPM	KEYWORD2
+getRev	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords